### PR TITLE
add iconv to libraries to make module compile correctly on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
 
+import sys
 from setuptools import setup, find_packages, Extension
 
 
 def read(file_path):
     with open(file_path) as fp:
         return fp.read()
+
+
+libraries = [
+    'zxing'
+]
+if sys.platform == 'darwin':
+    libraries.append('iconv')
 
 
 setup(
@@ -47,9 +55,7 @@ setup(
             extra_compile_args=[
                 '-std=c++11'
             ],
-            libraries=[
-                'zxing'
-            ]
+            libraries=libraries,
         ),
     ],
     include_package_data=True,


### PR DESCRIPTION
This fixes #1 by adding `iconv` to setup.py. Since the necessary functions are in libc on Linux, `iconv` is only added when building on macOS.