### PR TITLE
Expose "multi" as an API option.

### DIFF
--- a/tests/test_read_codes.py
+++ b/tests/test_read_codes.py
@@ -36,7 +36,18 @@ class ReadCodesTestCase(TestCase):
             'first zxinglight test qr code', 'second zxinglight test qr code'
         ])
 
+    def test_finding_one_of_two_qr_code(self):
+        self.assertEqual(
+            read_codes(get_image('two_qr_codes'), multi=False), ['first zxinglight test qr code'],
+        )
+
     def test_small_rotated_qr_code(self):
-        self.assertEqual(read_codes(get_image('small_rotated_qr_code'), try_harder=True), [
-            '217EXP0112'
-        ])
+        self.assertEqual(
+            read_codes(get_image('small_rotated_qr_code'), try_harder=True), ['217EXP0112'],
+        )
+
+    def test_small_rotated_qr_code_single(self):
+        self.assertEqual(
+            read_codes(get_image('small_rotated_qr_code'), try_harder=True, multi=False),
+            ['217EXP0112'],
+        )

--- a/zxinglight/__init__.py
+++ b/zxinglight/__init__.py
@@ -67,7 +67,7 @@ class BarcodeType(IntEnum):
     UPC_EAN_EXTENSION = 17
 
 
-def read_codes(image, barcode_type=BarcodeType.NONE, try_harder=False, hybrid=False):
+def read_codes(image, barcode_type=BarcodeType.NONE, try_harder=False, hybrid=False, multi=True):
     """
     Reads codes from a PIL Image.
 
@@ -77,6 +77,7 @@ def read_codes(image, barcode_type=BarcodeType.NONE, try_harder=False, hybrid=Fa
         try_harder (bool): Spend more time trying to find a barcode.
         hybrid (bool): Use Hybrid Binarizer instead of Global Binarizer. For more information,
             see `ZXing's documentation`_.
+        multi (bool): Search for multiple barcodes in a single image.
 
     Returns:
         A list of barcode values.
@@ -96,4 +97,4 @@ def read_codes(image, barcode_type=BarcodeType.NONE, try_harder=False, hybrid=Fa
     raw_image = grayscale_image.tobytes()
     width, height = grayscale_image.size
 
-    return zxing_read_codes(raw_image, width, height, barcode_type, try_harder, hybrid)
+    return zxing_read_codes(raw_image, width, height, barcode_type, try_harder, hybrid, multi)


### PR DESCRIPTION
ZXing has multiple detectors available. The two main ones, judging from their own CLI,
are GenericMultipleBarcodeReader and MultiFormatReader.

On my system, GenericMultipleBarcodeReader
is crashing (https://github.com/lubo/zxinglight/issues/5),
and anyway most of the time you don't need it, and it probably
is less reliable or quick than just searching for a single barcode.